### PR TITLE
CTCP-3471: Split configuration per environment

### DIFF
--- a/app/uk/gov/hmrc/transitmovementseisstub/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/transitmovementseisstub/config/AppConfig.scala
@@ -28,9 +28,11 @@ class AppConfig @Inject() (config: Configuration) {
   lazy val enforceAuthToken: Boolean = config.get[Boolean]("authorisation.enforce")
   lazy val authToken: String         = config.get[String]("authorisation.token")
 
-  lazy val enableProxyMode: Boolean = config.get[Boolean]("enable-proxy-mode")
+  lazy val enableProxyModeGb: Boolean = config.get[Boolean]("enable-proxy-mode.gb")
+  lazy val enableProxyModeXi: Boolean = config.get[Boolean]("enable-proxy-mode.xi")
 
-  lazy val clientAllowList: Seq[String] = config.get[Seq[String]]("client-allow-list")
+  lazy val clientAllowList: Seq[String]   = config.get[Seq[String]]("client-allow-list")
+  lazy val internalAllowList: Seq[String] = config.get[Seq[String]]("internal-allow-list")
 
   lazy val eisXi: EISInstanceConfig = config.get[EISInstanceConfig]("microservice.services.eis.xi")
   lazy val eisGb: EISInstanceConfig = config.get[EISInstanceConfig]("microservice.services.eis.gb")

--- a/app/uk/gov/hmrc/transitmovementseisstub/controllers/MessagesController.scala
+++ b/app/uk/gov/hmrc/transitmovementseisstub/controllers/MessagesController.scala
@@ -34,6 +34,7 @@ import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import uk.gov.hmrc.transitmovementseisstub.config.AppConfig
 import uk.gov.hmrc.transitmovementseisstub.connectors.EISConnectorProvider
 import uk.gov.hmrc.transitmovementseisstub.controllers.stream.StreamingParsers
+import uk.gov.hmrc.transitmovementseisstub.models.CustomsOffice
 
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
@@ -54,11 +55,10 @@ class MessagesController @Inject() (appConfig: AppConfig, cc: ControllerComponen
   private val UUID_PATTERN         = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$".r
   private val BEARER_TOKEN_PATTERN = "^Bearer (\\S+)$".r
 
-  def routeToEIScheck(client: String, customsOffice: String): Boolean = appConfig.clientAllowList.contains(
-    client
-  ) && appConfig.enableProxyMode && !customsOffice.isBlank && (customsOffice == "gb" || customsOffice == "xi")
+  def routeToEIScheck(client: String, customsOffice: CustomsOffice): Boolean =
+    (appConfig.clientAllowList.contains(client) && customsOffice.proxyEnabled(appConfig)) || appConfig.internalAllowList.contains(client)
 
-  def post(customsOffice: String): Action[Source[ByteString, _]] = Action.async(streamFromMemory) {
+  def post(customsOffice: CustomsOffice): Action[Source[ByteString, _]] = Action.async(streamFromMemory) {
     implicit request: Request[Source[ByteString, _]] =>
       implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
@@ -98,10 +98,10 @@ class MessagesController @Inject() (appConfig: AppConfig, cc: ControllerComponen
 
   }
 
-  private def routeToEIS(customsOffice: String)(implicit request: Request[Source[ByteString, _]], hc: HeaderCarrier) = {
-    val connector = customsOffice match {
-      case "gb" => eisConnectorProvider.gb
-      case "xi" => eisConnectorProvider.xi
+  private def routeToEIS(customsOffice: CustomsOffice)(implicit request: Request[Source[ByteString, _]], hc: HeaderCarrier) = {
+    val connector = (customsOffice: @unchecked) match {
+      case CustomsOffice.Gb => eisConnectorProvider.gb
+      case CustomsOffice.Xi => eisConnectorProvider.xi
     }
 
     connector.post(request.body)(hc).map {

--- a/app/uk/gov/hmrc/transitmovementseisstub/models/Bindings.scala
+++ b/app/uk/gov/hmrc/transitmovementseisstub/models/Bindings.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementseisstub.models
+
+import play.api.mvc.PathBindable
+
+object Bindings {
+
+  implicit val countryCodePathBindable: PathBindable[CustomsOffice] = new PathBindable[CustomsOffice] {
+
+    override def bind(key: String, value: String): Either[String, CustomsOffice] =
+      value.toLowerCase match {
+        case "gb" => Right(CustomsOffice.Gb)
+        case "xi" => Right(CustomsOffice.Xi)
+        case _    => Right(CustomsOffice.Unknown)
+      }
+
+    override def unbind(key: String, value: CustomsOffice): String = value.toString.toLowerCase
+  }
+
+}

--- a/app/uk/gov/hmrc/transitmovementseisstub/models/CustomsOffice.scala
+++ b/app/uk/gov/hmrc/transitmovementseisstub/models/CustomsOffice.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementseisstub.models
+
+import uk.gov.hmrc.transitmovementseisstub.config.AppConfig
+
+sealed trait CustomsOffice {
+  def proxyEnabled(appConfig: AppConfig): Boolean
+}
+
+object CustomsOffice {
+
+  case object Gb extends CustomsOffice {
+
+    def proxyEnabled(appConfig: AppConfig): Boolean =
+      appConfig.enableProxyModeGb
+  }
+
+  case object Xi extends CustomsOffice {
+
+    def proxyEnabled(appConfig: AppConfig): Boolean =
+      appConfig.enableProxyModeXi
+  }
+
+  case object Unknown extends CustomsOffice {
+    def proxyEnabled(appConfig: AppConfig): Boolean = false
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,10 @@ lazy val microservice = Project(appName, file("."))
     majorVersion := 0,
     scalaVersion := "2.13.8",
     PlayKeys.playDefaultPort := 9476,
+    RoutesKeys.routesImport ++= Seq(
+      "uk.gov.hmrc.transitmovementseisstub.models.Bindings._",
+      "uk.gov.hmrc.transitmovementseisstub.models.CustomsOffice"
+    ),
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     scalacOptions += "-Wconf:src=routes/.*:s"
   )

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,5 +1,6 @@
 # microservice specific routes
 
-POST        /movements/messages/:customsOffice     uk.gov.hmrc.transitmovementseisstub.controllers.MessagesController.post(customsOffice: String)
-
 POST        /movements/messages/                   uk.gov.hmrc.transitmovementseisstub.controllers.MessagesController.postToStub
+
+POST        /movements/messages/:customsOffice     uk.gov.hmrc.transitmovementseisstub.controllers.MessagesController.post(customsOffice: CustomsOffice)
+

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -94,7 +94,6 @@ authorisation {
 
 auditing {
   enabled = false
-  traceRequests = true
   consumer {
     baseUri {
       host = localhost

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -139,4 +139,9 @@ microservice {
 
 client-allow-list = []
 
-enable-proxy-mode = false
+internal-allow-list = []
+
+enable-proxy-mode {
+  gb = false
+  xi = false
+}

--- a/test/uk/gov/hmrc/transitmovementseisstub/controllers/MessagesControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementseisstub/controllers/MessagesControllerSpec.scala
@@ -41,6 +41,7 @@ import uk.gov.hmrc.transitmovementseisstub.config.AppConfig
 import uk.gov.hmrc.transitmovementseisstub.connectors.EISConnector
 import uk.gov.hmrc.transitmovementseisstub.connectors.EISConnectorProvider
 import uk.gov.hmrc.transitmovementseisstub.connectors.errors.RoutingError
+import uk.gov.hmrc.transitmovementseisstub.models.CustomsOffice
 
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -63,8 +64,10 @@ class MessagesControllerSpec
   private val mockEisConnectorProvider = mock[EISConnectorProvider]
   private val controller               = new MessagesController(appConfig, stubControllerComponents(), mockEisConnectorProvider)
 
-  override def beforeEach(): Unit =
+  override def beforeEach(): Unit = {
     reset(appConfig)
+    reset(mockEisConnectorProvider)
+  }
 
   lazy val formattedDate       = s"${HTTP_DATE_FORMATTER.format(OffsetDateTime.now(ZoneOffset.UTC))} UTC"
   lazy val brokenFormattedDate = s"${HTTP_DATE_FORMATTER.format(OffsetDateTime.now(ZoneOffset.UTC))} Z"
@@ -75,7 +78,7 @@ class MessagesControllerSpec
       when(appConfig.enforceAuthToken).thenReturn(false)
       val fakeRequest = FakeRequest(
         "POST",
-        routes.MessagesController.post("gb").url,
+        routes.MessagesController.post(CustomsOffice.Gb).url,
         FakeHeaders(
           Seq(
             "X-Correlation-Id"        -> UUID.randomUUID().toString,
@@ -88,7 +91,7 @@ class MessagesControllerSpec
         ),
         Source.empty[ByteString]
       )
-      val result = controller.post("gb")(fakeRequest)
+      val result = controller.post(CustomsOffice.Gb)(fakeRequest)
       status(result) shouldBe OK
     }
 
@@ -97,7 +100,7 @@ class MessagesControllerSpec
       when(appConfig.authToken).thenReturn("abc")
       val fakeRequest = FakeRequest(
         "POST",
-        routes.MessagesController.post("gb").url,
+        routes.MessagesController.post(CustomsOffice.Gb).url,
         FakeHeaders(
           Seq(
             "X-Correlation-Id"        -> UUID.randomUUID().toString,
@@ -110,14 +113,14 @@ class MessagesControllerSpec
         ),
         Source.empty[ByteString]
       )
-      val result = controller.post("gb")(fakeRequest)
+      val result = controller.post(CustomsOffice.Gb)(fakeRequest)
       status(result) shouldBe OK
     }
 
     "return 403 if a required header is missing" in {
       when(appConfig.enforceAuthToken).thenReturn(false)
-      val fakeRequest = FakeRequest("POST", routes.MessagesController.post("gb").url)
-      val result      = controller.post("gb")(fakeRequest)
+      val fakeRequest = FakeRequest("POST", routes.MessagesController.post(CustomsOffice.Gb).url)
+      val result      = controller.post(CustomsOffice.Gb)(fakeRequest)
       status(result) shouldBe FORBIDDEN
       contentAsJson(result) shouldBe Json.obj(
         "code"    -> "FORBIDDEN",
@@ -129,7 +132,7 @@ class MessagesControllerSpec
       when(appConfig.enforceAuthToken).thenReturn(false)
       val fakeRequest = FakeRequest(
         "POST",
-        routes.MessagesController.post("gb").url,
+        routes.MessagesController.post(CustomsOffice.Gb).url,
         FakeHeaders(
           Seq(
             "X-Correlation-Id"        -> "UUID.randomUUID().toString",
@@ -142,7 +145,7 @@ class MessagesControllerSpec
         ),
         Source.empty[ByteString]
       )
-      val result = controller.post("gb")(fakeRequest)
+      val result = controller.post(CustomsOffice.Gb)(fakeRequest)
       status(result) shouldBe FORBIDDEN
       contentAsJson(result) shouldBe Json.obj(
         "code"    -> "FORBIDDEN",
@@ -154,7 +157,7 @@ class MessagesControllerSpec
       when(appConfig.enforceAuthToken).thenReturn(false)
       val fakeRequest = FakeRequest(
         "POST",
-        routes.MessagesController.post("gb").url,
+        routes.MessagesController.post(CustomsOffice.Gb).url,
         FakeHeaders(
           Seq(
             "X-Correlation-Id"        -> UUID.randomUUID().toString,
@@ -167,7 +170,7 @@ class MessagesControllerSpec
         ),
         Source.empty[ByteString]
       )
-      val result = controller.post("gb")(fakeRequest)
+      val result = controller.post(CustomsOffice.Gb)(fakeRequest)
       status(result) shouldBe FORBIDDEN
       contentAsJson(result) shouldBe Json.obj(
         "code"    -> "FORBIDDEN",
@@ -185,7 +188,7 @@ class MessagesControllerSpec
         when(appConfig.enforceAuthToken).thenReturn(false)
         val fakeRequest = FakeRequest(
           "POST",
-          routes.MessagesController.post("gb").url,
+          routes.MessagesController.post(CustomsOffice.Gb).url,
           FakeHeaders(
             Seq(
               "X-Correlation-Id"        -> UUID.randomUUID().toString,
@@ -198,7 +201,7 @@ class MessagesControllerSpec
           ),
           Source.empty[ByteString]
         )
-        val result = controller.post("gb")(fakeRequest)
+        val result = controller.post(CustomsOffice.Gb)(fakeRequest)
         status(result) shouldBe FORBIDDEN
         contentAsJson(result) shouldBe Json.obj(
           "code"    -> "FORBIDDEN",
@@ -210,7 +213,7 @@ class MessagesControllerSpec
       when(appConfig.enforceAuthToken).thenReturn(false)
       val fakeRequest = FakeRequest(
         "POST",
-        routes.MessagesController.post("gb").url,
+        routes.MessagesController.post(CustomsOffice.Gb).url,
         FakeHeaders(
           Seq(
             "X-Correlation-Id"        -> UUID.randomUUID().toString,
@@ -223,7 +226,7 @@ class MessagesControllerSpec
         ),
         Source.empty[ByteString]
       )
-      val result = controller.post("gb")(fakeRequest)
+      val result = controller.post(CustomsOffice.Gb)(fakeRequest)
       status(result) shouldBe FORBIDDEN
       contentAsJson(result) shouldBe Json.obj(
         "code"    -> "FORBIDDEN",
@@ -236,7 +239,7 @@ class MessagesControllerSpec
       when(appConfig.authToken).thenReturn("easyas123")
       val fakeRequest = FakeRequest(
         "POST",
-        routes.MessagesController.post("gb").url,
+        routes.MessagesController.post(CustomsOffice.Gb).url,
         FakeHeaders(
           Seq(
             "X-Correlation-Id"        -> UUID.randomUUID().toString,
@@ -249,7 +252,7 @@ class MessagesControllerSpec
         ),
         Source.empty[ByteString]
       )
-      val result = controller.post("gb")(fakeRequest)
+      val result = controller.post(CustomsOffice.Gb)(fakeRequest)
       status(result) shouldBe FORBIDDEN
       contentAsJson(result) shouldBe Json.obj(
         "code"    -> "FORBIDDEN",
@@ -261,7 +264,7 @@ class MessagesControllerSpec
       when(appConfig.enforceAuthToken).thenReturn(false)
       val fakeRequest = FakeRequest(
         "POST",
-        routes.MessagesController.post("gb").url,
+        routes.MessagesController.post(CustomsOffice.Gb).url,
         FakeHeaders(
           Seq(
             "X-Correlation-Id"        -> UUID.randomUUID().toString,
@@ -274,7 +277,7 @@ class MessagesControllerSpec
         ),
         Source.empty[ByteString]
       )
-      val result = controller.post("gb")(fakeRequest)
+      val result = controller.post(CustomsOffice.Gb)(fakeRequest)
       status(result) shouldBe FORBIDDEN
       contentAsJson(result) shouldBe Json.obj(
         "code"    -> "FORBIDDEN",
@@ -286,7 +289,7 @@ class MessagesControllerSpec
       when(appConfig.enforceAuthToken).thenReturn(false)
       val fakeRequest = FakeRequest(
         "POST",
-        routes.MessagesController.post("gb").url,
+        routes.MessagesController.post(CustomsOffice.Gb).url,
         FakeHeaders(
           Seq(
             "X-Correlation-Id"        -> UUID.randomUUID().toString,
@@ -299,7 +302,7 @@ class MessagesControllerSpec
         ),
         Source.empty[ByteString]
       )
-      val result = controller.post("gb")(fakeRequest)
+      val result = controller.post(CustomsOffice.Gb)(fakeRequest)
       status(result) shouldBe FORBIDDEN
       contentAsJson(result) shouldBe Json.obj(
         "code"    -> "FORBIDDEN",
@@ -309,9 +312,10 @@ class MessagesControllerSpec
 
     val mockEISConnector = mock[EISConnector]
 
-    "return 200 when client id is in allow list and enable proxy is true" in {
+    "return 200 when client id is in allow list and enable proxy for GB is true" in {
       when(appConfig.clientAllowList).thenReturn(Seq("XYZ"))
-      when(appConfig.enableProxyMode).thenReturn(true)
+      when(appConfig.internalAllowList).thenReturn(Seq.empty)
+      when(appConfig.enableProxyModeGb).thenReturn(true)
       when(mockEisConnectorProvider.gb) thenReturn mockEISConnector
 
       when(
@@ -323,7 +327,7 @@ class MessagesControllerSpec
 
       val fakeRequest = FakeRequest(
         "POST",
-        routes.MessagesController.post("gb").url,
+        routes.MessagesController.post(CustomsOffice.Gb).url,
         FakeHeaders(
           Seq(
             "X-Client-Id"             -> "XYZ",
@@ -337,13 +341,16 @@ class MessagesControllerSpec
         ),
         Source.empty[ByteString]
       )
-      val result = controller.post("gb")(fakeRequest)
+      val result = controller.post(CustomsOffice.Gb)(fakeRequest)
       status(result) shouldBe OK
+      verify(mockEisConnectorProvider, times(0)).xi
+      verify(mockEisConnectorProvider, times(1)).gb
     }
 
     "implement stub logic when client not in allow list" in {
       when(appConfig.clientAllowList).thenReturn(Seq("XYZ"))
-      when(appConfig.enableProxyMode).thenReturn(true)
+      when(appConfig.internalAllowList).thenReturn(Seq.empty)
+      when(appConfig.enableProxyModeGb).thenReturn(true)
 
       when(
         mockEISConnector.post(any[Source[ByteString, _]])(
@@ -354,7 +361,7 @@ class MessagesControllerSpec
 
       val fakeRequest = FakeRequest(
         "POST",
-        routes.MessagesController.post("gb").url,
+        routes.MessagesController.post(CustomsOffice.Gb).url,
         FakeHeaders(
           Seq(
             "X-Client-Id"             -> "notInAllowList",
@@ -368,13 +375,17 @@ class MessagesControllerSpec
         ),
         Source.empty[ByteString]
       )
-      val result = controller.post("gb")(fakeRequest)
+      val result = controller.post(CustomsOffice.Gb)(fakeRequest)
       status(result) shouldBe OK
+      verify(mockEisConnectorProvider, times(0)).xi
+      verify(mockEisConnectorProvider, times(0)).gb
     }
 
     "implement stub logic when enable proxy is false" in {
       when(appConfig.clientAllowList).thenReturn(Seq("XYZ"))
-      when(appConfig.enableProxyMode).thenReturn(false)
+      when(appConfig.internalAllowList).thenReturn(Seq.empty)
+      when(appConfig.enableProxyModeGb).thenReturn(false)
+      when(appConfig.enableProxyModeXi).thenReturn(true)
 
       when(
         mockEISConnector.post(any[Source[ByteString, _]])(
@@ -385,7 +396,7 @@ class MessagesControllerSpec
 
       val fakeRequest = FakeRequest(
         "POST",
-        routes.MessagesController.post("gb").url,
+        routes.MessagesController.post(CustomsOffice.Gb).url,
         FakeHeaders(
           Seq(
             "X-Client-Id"             -> "XYZ",
@@ -399,8 +410,82 @@ class MessagesControllerSpec
         ),
         Source.empty[ByteString]
       )
-      val result = controller.post("gb")(fakeRequest)
+      val result = controller.post(CustomsOffice.Gb)(fakeRequest)
       status(result) shouldBe OK
+      verify(mockEisConnectorProvider, times(0)).xi
+      verify(mockEisConnectorProvider, times(0)).gb
     }
+
+    "return 200 when client id is in allow list and enable proxy for XI is true" in {
+      when(appConfig.clientAllowList).thenReturn(Seq("XYZ"))
+      when(appConfig.internalAllowList).thenReturn(Seq.empty)
+      when(appConfig.enableProxyModeGb).thenReturn(false)
+      when(appConfig.enableProxyModeXi).thenReturn(true)
+      when(mockEisConnectorProvider.xi) thenReturn mockEISConnector
+
+      when(
+        mockEISConnector.post(any[Source[ByteString, _]])(
+          any[HeaderCarrier]
+        )
+      )
+        .thenReturn(Future.successful(Right(())))
+
+      val fakeRequest = FakeRequest(
+        "POST",
+        routes.MessagesController.post(CustomsOffice.Xi).url,
+        FakeHeaders(
+          Seq(
+            "X-Client-Id"             -> "XYZ",
+            "X-Correlation-Id"        -> UUID.randomUUID().toString,
+            "X-Conversation-Id"       -> UUID.randomUUID().toString,
+            HeaderNames.DATE          -> formattedDate,
+            HeaderNames.ACCEPT        -> "application/xml",
+            HeaderNames.AUTHORIZATION -> "Bearer abc",
+            HeaderNames.CONTENT_TYPE  -> "application/xml"
+          )
+        ),
+        Source.empty[ByteString]
+      )
+      val result = controller.post(CustomsOffice.Xi)(fakeRequest)
+      status(result) shouldBe OK
+      verify(mockEisConnectorProvider, times(1)).xi
+      verify(mockEisConnectorProvider, times(0)).gb
+    }
+
+    "return 200 when client id is in internal allow list and enable proxy for GB is false" in {
+      when(appConfig.internalAllowList).thenReturn(Seq("XYZ"))
+      when(appConfig.clientAllowList).thenReturn(Seq())
+      when(appConfig.enableProxyModeGb).thenReturn(false)
+      when(mockEisConnectorProvider.gb) thenReturn mockEISConnector
+
+      when(
+        mockEISConnector.post(any[Source[ByteString, _]])(
+          any[HeaderCarrier]
+        )
+      )
+        .thenReturn(Future.successful(Right(())))
+
+      val fakeRequest = FakeRequest(
+        "POST",
+        routes.MessagesController.post(CustomsOffice.Gb).url,
+        FakeHeaders(
+          Seq(
+            "X-Client-Id"             -> "XYZ",
+            "X-Correlation-Id"        -> UUID.randomUUID().toString,
+            "X-Conversation-Id"       -> UUID.randomUUID().toString,
+            HeaderNames.DATE          -> formattedDate,
+            HeaderNames.ACCEPT        -> "application/xml",
+            HeaderNames.AUTHORIZATION -> "Bearer abc",
+            HeaderNames.CONTENT_TYPE  -> "application/xml"
+          )
+        ),
+        Source.empty[ByteString]
+      )
+      val result = controller.post(CustomsOffice.Gb)(fakeRequest)
+      status(result) shouldBe OK
+      verify(mockEisConnectorProvider, times(0)).xi
+      verify(mockEisConnectorProvider, times(1)).gb
+    }
+
   }
 }

--- a/test/uk/gov/hmrc/transitmovementseisstub/models/BindingSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementseisstub/models/BindingSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementseisstub.models
+
+import org.scalacheck.Gen
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.forAll
+
+class BindingSpec extends AnyFreeSpec with Matchers {
+
+  "CustomsOffice path bindable" - {
+
+    "bind" - {
+
+      "gb should return Gb" in {
+        Bindings.countryCodePathBindable.bind("a", "gb") mustBe Right(CustomsOffice.Gb)
+      }
+
+      "xi should return Xi" in {
+        Bindings.countryCodePathBindable.bind("a", "xi") mustBe Right(CustomsOffice.Xi)
+      }
+
+      "anything else should return Unknown" in forAll(Gen.alphaNumStr) {
+        str =>
+          Bindings.countryCodePathBindable.bind("a", str) mustBe Right(CustomsOffice.Unknown)
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
We need to be able to turn GB/XI trader test on and off at will, and have an override client list